### PR TITLE
Added Shiny launch command for local install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ These commands will enable MaGIC to run from the command line. We also developed
 ```
 R -e "shiny::runApp('shiny/MagicWeb/', launch.browser = T)"
 ```
+Alternatively, if MaGIC has been installed locally as instructed above, use the following command instead:
+
+```
+R -e ".libPaths('libraries'); shiny::runApp('./shiny/MagicWeb/', launch.browser = T)"
+```
+
 If you change your mind and want to uninstall MaGIC, you can just delete the whole folder:
 
 ```


### PR DESCRIPTION
The command `R -e "shiny::runApp('shiny/MagicWeb/', launch.browser = T)"` won't work if shiny R package is not installed system-wide. To have it work with a local install of the shiny package, the path to package libraries needs first to be updated with the directory where shiny has been installed. If it has been installed in the "libraries" directory, the command should thus be: `R -e ".libPaths('libraries'); shiny::runApp('./shiny/MagicWeb/', launch.browser = T)"`.